### PR TITLE
Keeping origin IP host also for RootTLD

### DIFF
--- a/pkg/server/http_server.go
+++ b/pkg/server/http_server.go
@@ -137,7 +137,6 @@ func (h *HTTPServer) logger(handler http.Handler) http.HandlerFunc {
 			for _, domain := range h.options.Domains {
 				if h.options.RootTLD && stringsutil.HasSuffixI(r.Host, domain) {
 					ID := domain
-					host, _, _ := net.SplitHostPort(r.RemoteAddr)
 					interaction := &Interaction{
 						Protocol:      "http",
 						UniqueID:      r.Host,


### PR DESCRIPTION
If RootTLD option was enabled, host was always set to remote addr - overwriting any previous setting of the host to the originIP header value. This resulted in that the client IP always was being reported as 127.0.0.1 if running with wildcard and behind reverse proxy.